### PR TITLE
Update README.

Reown AppKit is a plug-and-play Safe App frontend for managing smart contract wallets (like Gnosis Safe) — but on steroid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # automatisch-appkit
-Reown AppKit is a plug-and-play Safe App frontend for managing smart contract wallets (like Gnosis Safe) — but on steroids
+
+## Setup
+
+1. Create GitHub repo and upload these files.
+2. Add GitHub Secrets:
+   - `SAFE_ADDRESS`
+   - `SIGNER_KEY`
+   - `DISCORD_WEBHOOK`
+   - `RPC_URL`
+   - `SAFE_TX_SERVICE_URL`
+
+3. Deploy on Vercel linked to the repo.
+4. Merge PR or label issue to create a Safe transaction.
+
+Use the AppKit frontend to approve and execute transactions.


### PR DESCRIPTION
change 